### PR TITLE
fix input default color

### DIFF
--- a/library/src/main/java/com/keijumt/passwordview/PasswordView.kt
+++ b/library/src/main/java/com/keijumt/passwordview/PasswordView.kt
@@ -62,7 +62,7 @@ class PasswordView @JvmOverloads constructor(
     private val betweenMargin =
         array.getDimensionPixelOffset(R.styleable.PasswordView_password_between_margin, DEFAULT_BETWEEN_MARGIN)
     private val inputColor = array.getColor(R.styleable.PasswordView_password_input_color, DEFAULT_INPUT_COLOR)
-    private val notInputColor = array.getColor(R.styleable.PasswordView_password_input_color, DEFAULT_NOT_INPUT_COLOR)
+    private val notInputColor = array.getColor(R.styleable.PasswordView_password_not_input_color, DEFAULT_NOT_INPUT_COLOR)
     private val outlineColor = array.getColor(R.styleable.PasswordView_password_outline_color, DEFAULT_OUTLINE_COLOR)
     private val correctColor = array.getColor(R.styleable.PasswordView_password_correct_color, DEFAULT_CORRECT_COLOR)
     private val incorrectColor =


### PR DESCRIPTION
i have edit the PasswordView class to modify the not input color bug
the case : when i change the input color >

the expectations : the password dots remain the same and when i press a button the input dot colored to colo i selected.

what happens : the not input color changed immediately to new input color.

what i have done: i changed the styleable for notInputColor KEY to DEFAULT_NOT_INPUT_COLOR